### PR TITLE
Updated metadata for GNOME Shell 41 support.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,9 +3,10 @@
   "name": "LAN IP Address", 
   "shell-version": [
     "3.38",
-    "40"
+    "40",
+    "41"
   ], 
   "url": "https://github.com/Josholith/gnome-extension-lan-ip-address", 
   "uuid": "lan-ip-address@mrhuber.com", 
-  "version": 7
+  "version": 8
 }


### PR DESCRIPTION
No functional changes were needed, it just worked on my Arch system with GNOME 41. Extension version bump. Closes #10.